### PR TITLE
feat: wire reopenLastBookOnLaunch preference (C2)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,10 @@ function useOnboardingRedirect() {
   const hasCompletedOnboarding = usePreferencesStore(
     (s) => s.hasCompletedOnboarding,
   );
+  const reopenLastBookOnLaunch = usePreferencesStore(
+    (s) => s.reopenLastBookOnLaunch,
+  );
+  const lastOpenedBookId = usePreferencesStore((s) => s.lastOpenedBookId);
   const hasNavigated = useRef(false);
 
   useEffect(() => {
@@ -38,6 +42,14 @@ function useOnboardingRedirect() {
     ) {
       hasNavigated.current = true;
       router.replace("/(tabs)" as any);
+    } else if (
+      hasCompletedOnboarding &&
+      reopenLastBookOnLaunch &&
+      lastOpenedBookId &&
+      !hasNavigated.current
+    ) {
+      hasNavigated.current = true;
+      router.push(`/reader/${lastOpenedBookId}` as any);
     }
   }, [isHydrated, hasCompletedOnboarding]);
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,7 @@
-import { DatabaseProvider } from "@/src/database/useDatabase";
+import {
+  DatabaseProvider,
+  useDatabaseStatus,
+} from "@/src/database/useDatabase";
 import {
   usePreferencesStore,
   useTamaguiThemeName,
@@ -21,10 +24,6 @@ function useOnboardingRedirect() {
   const hasCompletedOnboarding = usePreferencesStore(
     (s) => s.hasCompletedOnboarding,
   );
-  const reopenLastBookOnLaunch = usePreferencesStore(
-    (s) => s.reopenLastBookOnLaunch,
-  );
-  const lastOpenedBookId = usePreferencesStore((s) => s.lastOpenedBookId);
   const hasNavigated = useRef(false);
 
   useEffect(() => {
@@ -42,16 +41,39 @@ function useOnboardingRedirect() {
     ) {
       hasNavigated.current = true;
       router.replace("/(tabs)" as any);
-    } else if (
-      hasCompletedOnboarding &&
-      reopenLastBookOnLaunch &&
-      lastOpenedBookId &&
-      !hasNavigated.current
-    ) {
+    }
+  }, [isHydrated, hasCompletedOnboarding]);
+}
+
+/** Navigates to the last-read book once DB is ready. Runs inside DatabaseProvider. */
+function useReopenLastBook() {
+  const router = useRouter();
+  const { isReady: dbReady } = useDatabaseStatus();
+  const isHydrated = usePreferencesStore((s) => s.isHydrated);
+  const hasCompletedOnboarding = usePreferencesStore(
+    (s) => s.hasCompletedOnboarding,
+  );
+  const reopenLastBookOnLaunch = usePreferencesStore(
+    (s) => s.reopenLastBookOnLaunch,
+  );
+  const lastOpenedBookId = usePreferencesStore((s) => s.lastOpenedBookId);
+  const hasNavigated = useRef(false);
+
+  useEffect(() => {
+    if (!isHydrated || !dbReady || !hasCompletedOnboarding) return;
+
+    console.log("[ReopenBook] ready:", {
+      reopenLastBookOnLaunch,
+      lastOpenedBookId,
+      hasNavigated: hasNavigated.current,
+    });
+
+    if (reopenLastBookOnLaunch && lastOpenedBookId && !hasNavigated.current) {
+      console.log("[ReopenBook] navigating to reader:", lastOpenedBookId);
       hasNavigated.current = true;
       router.push(`/reader/${lastOpenedBookId}` as any);
     }
-  }, [isHydrated, hasCompletedOnboarding]);
+  }, [isHydrated, dbReady, hasCompletedOnboarding]);
 }
 
 function AppContent() {
@@ -65,6 +87,7 @@ function AppContent() {
   return (
     <TamaguiProvider config={tamaguiConfig} defaultTheme={themeName}>
       <DatabaseProvider>
+        <ReopenLastBookGate />
         <StatusBar style={statusBarStyle} />
         <Stack
           screenOptions={{
@@ -98,6 +121,12 @@ function AppContent() {
       </DatabaseProvider>
     </TamaguiProvider>
   );
+}
+
+/** Renderless component that runs useReopenLastBook inside DatabaseProvider */
+function ReopenLastBookGate() {
+  useReopenLastBook();
+  return null;
 }
 
 export default function RootLayout() {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -62,14 +62,7 @@ function useReopenLastBook() {
   useEffect(() => {
     if (!isHydrated || !dbReady || !hasCompletedOnboarding) return;
 
-    console.log("[ReopenBook] ready:", {
-      reopenLastBookOnLaunch,
-      lastOpenedBookId,
-      hasNavigated: hasNavigated.current,
-    });
-
     if (reopenLastBookOnLaunch && lastOpenedBookId && !hasNavigated.current) {
-      console.log("[ReopenBook] navigating to reader:", lastOpenedBookId);
       hasNavigated.current = true;
       router.push(`/reader/${lastOpenedBookId}` as any);
     }

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,13 +1,27 @@
 import { ThemePicker } from "@/src/components/ThemePicker";
-import { useThemeColors } from "@/src/stores/preferencesStore";
+import {
+  usePreferencesStore,
+  useThemeColors,
+} from "@/src/stores/preferencesStore";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function SettingsScreen() {
   const colors = useThemeColors();
   const router = useRouter();
+  const reopenLastBook = usePreferencesStore((s) => s.reopenLastBookOnLaunch);
+  const setReopenLastBook = usePreferencesStore(
+    (s) => s.setReopenLastBookOnLaunch,
+  );
 
   return (
     <SafeAreaView
@@ -30,6 +44,37 @@ export default function SettingsScreen() {
           Appearance
         </Text>
         <ThemePicker showAccents />
+
+        <Text
+          style={[
+            styles.sectionTitle,
+            styles.sectionTitleSpaced,
+            { color: colors.textSecondary },
+          ]}
+        >
+          Behavior
+        </Text>
+
+        <View style={[styles.settingRow, { backgroundColor: colors.surface }]}>
+          <View style={styles.settingInfo}>
+            <Text style={[styles.settingLabel, { color: colors.text }]}>
+              Reopen last book on launch
+            </Text>
+            <Text
+              style={[
+                styles.settingDescription,
+                { color: colors.textSecondary },
+              ]}
+            >
+              Automatically open where you left off
+            </Text>
+          </View>
+          <Switch
+            value={reopenLastBook}
+            onValueChange={setReopenLastBook}
+            trackColor={{ false: colors.border, true: colors.accent }}
+          />
+        </View>
 
         <Text style={[styles.tip, { color: colors.textSecondary }]}>
           Font and reading settings can be changed while reading a book.
@@ -63,6 +108,28 @@ const styles = StyleSheet.create({
     textTransform: "uppercase",
     letterSpacing: 0.5,
     marginBottom: 12,
+  },
+  sectionTitleSpaced: {
+    marginTop: 28,
+  },
+  settingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: 14,
+    borderRadius: 12,
+  },
+  settingInfo: {
+    flex: 1,
+    marginRight: 12,
+  },
+  settingLabel: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  settingDescription: {
+    fontSize: 12,
+    marginTop: 2,
   },
   tip: {
     fontSize: 13,

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -25,6 +25,7 @@ interface PreferencesActions {
   setLibraryViewMode: (mode: LibraryViewMode) => void;
   setShelvesViewMode: (mode: ShelvesViewMode) => void;
   setLastOpenedBook: (bookId: string | undefined) => void;
+  setReopenLastBookOnLaunch: (enabled: boolean) => void;
   setHasCompletedOnboarding: (completed: boolean) => void;
   reset: () => void;
   setHydrated: (isHydrated: boolean) => void;
@@ -84,6 +85,9 @@ export const usePreferencesStore = create<PreferncesStore>()(
 
       setLastOpenedBook: (lastOpenedBookId) => set({ lastOpenedBookId }),
 
+      setReopenLastBookOnLaunch: (reopenLastBookOnLaunch) =>
+        set({ reopenLastBookOnLaunch }),
+
       setHasCompletedOnboarding: (hasCompletedOnboarding) =>
         set({ hasCompletedOnboarding }),
 
@@ -103,6 +107,7 @@ export const usePreferencesStore = create<PreferncesStore>()(
         libraryViewMode: state.libraryViewMode,
         shelvesViewMode: state.shelvesViewMode,
         lastOpenedBookId: state.lastOpenedBookId,
+        reopenLastBookOnLaunch: state.reopenLastBookOnLaunch,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
       }),
       onRehydrateStorage: () => (state) => {


### PR DESCRIPTION
## Summary
Two Phase 1 cleanup items in one PR.

### E3: Switch library search to DB-level searchBooks()
Replaces the in-memory Array.filter in useBookSearch with the indexed SQL LIKE query from repository.searchBooks(). The hook debounces queries by 300ms, maps matched IDs back to in-memory BookWithProgress objects, and falls back to in-memory filtering on DB failure. Same interface — no changes to library.tsx.

### E4: Fix code typos
- migrations/index.ts: "Curretn" → "Current", "Runn all" → "Run all"
- useLibrary.ts: "fromd atabase" → "from database"

## Testing
- TypeScript and eslint clean
- Search works with same UI behavior

Closes #3
Closes #4
